### PR TITLE
backup.sh: fix string expansion for `OCC` variable

### DIFF
--- a/nextcloud/backup.sh
+++ b/nextcloud/backup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 start=`date +%s`
-OCC=`/var/www/html/occ`
+OCC="/var/www/html/occ"
 
 if [ -z "${RESTIC_REPOSITORY}" ]; then
   echo Restic repo is undifined. Skipping backup.


### PR DESCRIPTION
Hi @steffen-p,
when trying to run the backup script I got following error:
  `Could not open input file: Nextcloud`
I think it is due to a wrong string expansion. Do you see the same issue on your end?

Except from the backup everything works like a charm so far. Thanks a lot!